### PR TITLE
Updated usage example in js file

### DIFF
--- a/src/gibberish-aes.js
+++ b/src/gibberish-aes.js
@@ -12,7 +12,7 @@
 *
 * License: MIT
 *
-* Usage: Gibberish.encrypt("secret", "password", 256)
+* Usage: GibberishAES.enc("secret", "password")
 * Outputs: AES Encrypted text encoded in Base64
 */
 


### PR DESCRIPTION
The example in the header of the js file seems to use outdated (?) syntax.
