### PR TITLE
Removed trailing line break from decoded string.

### DIFF
--- a/src/gibberish-aes.js
+++ b/src/gibberish-aes.js
@@ -584,6 +584,8 @@ var GibberishAES = (function(){
         cryptArr = cryptArr.slice(16, cryptArr.length);
         // Take off the Salted__ffeeddcc
         string = rawDecrypt(cryptArr, key, iv, binary);
+        // Remove trailing line break! : Kosso
+        string = string.replace(/\n$/,'');
         return string;
     },
     


### PR DESCRIPTION
Just spent some time wondering where a line break was coming from in some code I'm using gibberish in. Turns out that one appeared to still left here in the string in the dec function. 