### PR TITLE
Expose rawDecrypt for use after encoding directly with rawEncrypt.

### DIFF
--- a/src/gibberish-aes.js
+++ b/src/gibberish-aes.js
@@ -982,6 +982,7 @@ var GibberishAES = (function(){
         "Decrypt":Decrypt,
         "s2a":s2a,
         "rawEncrypt":rawEncrypt,
+        "rawDecrypt":rawDecrypt,
         "dec":dec,
         "openSSLKey":openSSLKey,
         "a2h":a2h,


### PR DESCRIPTION
If you wish to encrypt using your own custom IV and cipherKey, you can use rawEncrypt and rawDecrypt.
