### PR TITLE
Minor improvement gibberish-aes.js

### DIFF
--- a/src/gibberish-aes.js
+++ b/src/gibberish-aes.js
@@ -374,7 +374,7 @@
         // rotate 4-byte word w left by one byte
         var tmp = w[0],
         i;
-        for (i = 0; i < 4; i++) {
+        for (i = 0; i < 3; i++) {
             w[i] = w[i + 1];
         }
         w[3] = tmp;


### PR DESCRIPTION
just a detail in line 377: as w is a 4-byte word, you need to rotate w[0],w[1],w[2] and set w[3]=temp. So the loop goes from 0 to 2. You just save one useless calculation
