### PR TITLE
readme : openssl Interop missing message digest param

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,14 +40,14 @@ Thanks to :
 
 #### OpenSSL Interop
 
-  In Javascript
-  
-        GibberishAES.enc("Made with Gibberish\n", "password");
-        // Outputs: "U2FsdGVkX1+21O5RB08bavFTq7Yq/gChmXrO3f00tvJaT55A5pPvqw0zFVnHSW1o"
-        
-  On the command line
-  
-        echo "U2FsdGVkX1+21O5RB08bavFTq7Yq/gChmXrO3f00tvJaT55A5pPvqw0zFVnHSW1o" | openssl enc -d -aes-256-cbc -a -k password
+In Javascript
+
+    GibberishAES.enc("Made with Gibberish\n", "password");
+    // Outputs: "U2FsdGVkX1+21O5RB08bavFTq7Yq/gChmXrO3f00tvJaT55A5pPvqw0zFVnHSW1o"
+
+On the command line
+
+    echo "U2FsdGVkX1+21O5RB08bavFTq7Yq/gChmXrO3f00tvJaT55A5pPvqw0zFVnHSW1o" | openssl enc -d -aes-256-cbc -a -k password -md md5
 
 
 ### Requirements
@@ -68,4 +68,3 @@ basic GibberishAES does not.
 ### Design Factors
 
 It only supports CBC AES encryption mode, and it's built to be compatible with OpenSSL.
-


### PR DESCRIPTION
Missing message digest parameter in openssl command in Readme

Before : 

```
echo "U2FsdGVkX1+21O5RB08bavFTq7Yq/gChmXrO3f00tvJaT55A5pPvqw0zFVnHSW1o" | openssl enc -d -aes-256-cbc -a -k password
bad decrypt
139695305401600:error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt:../crypto/evp/evp_enc.c:535:
5�3L+}�ÿL>L
```

After : 

```
echo "U2FsdGVkX1+21O5RB08bavFTq7Yq/gChmXrO3f00tvJaT55A5pPvqw0zFVnHSW1o" | openssl enc -d -aes-256-cbc -a -k password -md md5
Made with Gibberish
```